### PR TITLE
Fix keybindings not working in subsequent sessions

### DIFF
--- a/src/main/kotlin/app/qwertz/quickjoin/config/QuickJoinConfig.kt
+++ b/src/main/kotlin/app/qwertz/quickjoin/config/QuickJoinConfig.kt
@@ -53,6 +53,7 @@ class QuickJoinConfig : Config(Mod(QuickJoin.NAME, ModType.HYPIXEL, "/QuickJoin.
 
         guis = loadConfig()
         var config: QuickJoinConfig = this // Assign the current instance of QuickJoinConfig to config
+        initialize()
         registerKeyBind(QJKeyBind) {
             if (config.EnableKeyBind) {
                 if (!config.enabled) {
@@ -68,7 +69,6 @@ class QuickJoinConfig : Config(Mod(QuickJoin.NAME, ModType.HYPIXEL, "/QuickJoin.
                 }
             }
         }
-        initialize()
 
     }
 }


### PR DESCRIPTION
Before this, custom keybindings only worked after the first launch. Once the player customized them and launched another session, only the default keybinding ('x') would work.