### PR TITLE
Support all 26.1 versions

### DIFF
--- a/versions/26.1-fabric/src/main/resources/fabric.mod.json
+++ b/versions/26.1-fabric/src/main/resources/fabric.mod.json
@@ -21,7 +21,7 @@
   "environment": "client",
   "depends": {
     "fabricloader": ">=0.15.11",
-    "minecraft": "26.1",
+    "minecraft": "~26.1",
     "fabric-api": "*",
     "modernconfig": "*"
   },


### PR DESCRIPTION
the tilde means all 26.1.x versions will be supported, which is typically fine for minecraft 26+ as all .x versions are meant to be bug fixes and other patches that likely do not matter